### PR TITLE
PB-1849: Update recommendation from Buster to Bookworm.

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -59,7 +59,7 @@ The build process can considerably be speed up if the layers are ordered in good
 
 ```Dockerfile
 
-FROM debian-buster              > the base layer
+FROM debian-bookworm              > the base layer
 
 RUN apt-get update && \         \
     apt-get install -y \         |


### PR DESCRIPTION
This should have been in https://github.com/geoadmin/doc-guidelines/pull/12
I have not found any other reference to Buster in this repository.